### PR TITLE
upgrading to 0.29.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ org.gradle.jvmargs=-Xmx2G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.29.0+1.16
+	fabric_version=0.29.3+1.16


### PR DESCRIPTION
Should fix the following crash report:

```
java.lang.NoSuchFieldError: field_6002
    at net.minecraft.entity.LivingEntity.handler$zge000$onEntityKilledOther(LivingEntity.java:3764)
    at net.minecraft.entity.LivingEntity.onDeath(LivingEntity.java:1217)
    at net.minecraft.entity.LivingEntity.damage(LivingEntity.java:1075)
    at net.minecraft.entity.passive.AnimalEntity.damage(AnimalEntity.java:72)
```